### PR TITLE
feat: Refactor video generation to use Render endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,98 +1,82 @@
-<p align="center">
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
-</p>
+# YouTube Video Generation Service
 
-[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
-[circleci-url]: https://circleci.com/gh/nestjs/nest
+This project is a NestJS application that automates the generation of YouTube videos. It leverages an external Render endpoint to create videos based on a given prompt, and then uploads them to YouTube.
 
-  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
-    <p align="center">
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
-<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
-<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
-<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
-<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
-  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg" alt="Donate us"/></a>
-    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
-  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow" alt="Follow us on Twitter"></a>
-</p>
-  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
-  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
+## Features
 
-## Description
+- **Automated Video Generation**: Provide a prompt and the service will generate a video using an external API.
+- **YouTube Integration**: Automatically uploads the generated video to a specified YouTube channel.
+- **MongoDB Integration**: Stores job details and video metadata in a MongoDB database.
 
-[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
+## Prerequisites
 
-## Project setup
+- Node.js (v14 or higher)
+- npm
+- MongoDB
+- A YouTube API key with OAuth 2.0 credentials
 
-```bash
-$ npm install
-```
+## Getting Started
 
-## Compile and run the project
+1. **Clone the repository:**
 
-```bash
-# development
-$ npm run start
+   ```bash
+   git clone https://github.com/your-username/your-repo-name.git
+   cd your-repo-name
+   ```
 
-# watch mode
-$ npm run start:dev
+2. **Install dependencies:**
 
-# production mode
-$ npm run start:prod
-```
+   ```bash
+   npm install
+   ```
 
-## Run tests
+3. **Set up environment variables:**
 
-```bash
-# unit tests
-$ npm run test
+   Create a `.env` file in the root of the project and add the following variables:
 
-# e2e tests
-$ npm run test:e2e
+   ```env
+   MONGO_URI=your_mongodb_connection_string
+   YOUTUBE_CLIENT_ID=your_youtube_client_id
+   YOUTUBE_CLIENT_SECRET=your_youtube_client_secret
+   YOUTUBE_REDIRECT_URI=your_youtube_redirect_uri
+   YOUTUBE_REFRESH_TOKEN=your_youtube_refresh_token
+   ```
 
-# test coverage
-$ npm run test:cov
-```
+4. **Run the application:**
 
-## Deployment
+   ```bash
+   npm run start:dev
+   ```
 
-When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.
+The application will be running on `http://localhost:3000`.
 
-If you are looking for a cloud-based platform to deploy your NestJS application, check out [Mau](https://mau.nestjs.com), our official platform for deploying NestJS applications on AWS. Mau makes deployment straightforward and fast, requiring just a few simple steps:
+## API Endpoints
 
-```bash
-$ npm install -g @nestjs/mau
-$ mau deploy
-```
+### Generate a new video
 
-With Mau, you can deploy your application in just a few clicks, allowing you to focus on building features rather than managing infrastructure.
+- **POST** `/automate/video`
 
-## Resources
+  This endpoint initiates the video generation process.
 
-Check out a few resources that may come in handy when working with NestJS:
+  **Request Body:**
 
-- Visit the [NestJS Documentation](https://docs.nestjs.com) to learn more about the framework.
-- For questions and support, please visit our [Discord channel](https://discord.gg/G7Qnnhy).
-- To dive deeper and get more hands-on experience, check out our official video [courses](https://courses.nestjs.com/).
-- Deploy your application to AWS with the help of [NestJS Mau](https://mau.nestjs.com) in just a few clicks.
-- Visualize your application graph and interact with the NestJS application in real-time using [NestJS Devtools](https://devtools.nestjs.com).
-- Need help with your project (part-time to full-time)? Check out our official [enterprise support](https://enterprise.nestjs.com).
-- To stay in the loop and get updates, follow us on [X](https://x.com/nestframework) and [LinkedIn](https://linkedin.com/company/nestjs).
-- Looking for a job, or have a job to offer? Check out our official [Jobs board](https://jobs.nestjs.com).
+  ```json
+  {
+    "prompt": "A video about the importance of exercise."
+  }
+  ```
 
-## Support
+  **Response:**
 
-Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
+  The endpoint returns a `Job` object with details about the video generation task.
 
-## Stay in touch
+## How it Works
 
-- Author - [Kamil Myśliwiec](https://twitter.com/kammysliwiec)
-- Website - [https://nestjs.com](https://nestjs.com/)
-- Twitter - [@nestframework](https://twitter.com/nestframework)
+1. **Script Generation**: The `ScriptService` generates a script, title, description, and tags based on the provided prompt.
+2. **Video Generation**: The application sends a request to the Render endpoint (`https://mpt-mkrv.onrender.com/api/v1/videos`) with the prompt and script.
+3. **Video Upload**: The generated video is then uploaded to YouTube using the `YoutubeService`.
+4. **Database Storage**: The job details, including the video URL and YouTube video ID, are stored in a MongoDB database.
 
 ## License
 
-Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).
+This project is licensed under the MIT License.

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "prettier": "^3.4.2",
         "source-map-support": "^0.5.21",
         "supertest": "^7.0.0",
-        "ts-jest": "^29.2.5",
+        "ts-jest": "^29.4.5",
         "ts-loader": "^9.5.2",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
@@ -269,6 +269,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2534,6 +2535,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2712,6 +2714,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.3.tgz",
       "integrity": "sha512-ogEK+GriWodIwCw6buQ1rpcH4Kx+G7YQ9EwuPySI3rS05pSdtQ++UhucjusSI9apNidv+QURBztJkRecwwJQXg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.0.0",
         "iterare": "1.2.1",
@@ -2759,6 +2762,7 @@
       "integrity": "sha512-5lTni0TCh8x7bXETRD57pQFnKnEg1T6M+VLE7wAmyQRIecKQU+2inRGZD+A4v2DC1I04eA0WffP0GKLxjOKlzw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2811,6 +2815,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.3.tgz",
       "integrity": "sha512-hEDNMlaPiBO72fxxX/CuRQL3MEhKRc/sIYGVoXjrnw6hTxZdezvvM6A95UaLsYknfmcZZa/CdG1SMBZOu9agHQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.1.0",
@@ -3109,6 +3114,7 @@
       "integrity": "sha512-Q5FsI3Cw0fGMXhmsg7c08i4EmXCrcl+WnAxb6LYOLHw4JFFC3yzmx9LaXZ7QMbA+JZXbigU2TirI7RAfO0Qlnw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@xhmikosr/bin-wrapper": "^13.0.5",
@@ -3181,6 +3187,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.23"
@@ -3544,6 +3551,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3697,6 +3705,7 @@
       "integrity": "sha512-oaNE4MzsA6uO7HcsjUvqzz19lYIRsV6I1Dc6iOvgwYYDiOeF7/9b2E/PE0UW2ccwpgWPVUedjltYXQXVKFd4EA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3853,6 +3862,7 @@
       "integrity": "sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.36.0",
         "@typescript-eslint/types": "8.36.0",
@@ -4818,6 +4828,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4863,6 +4874,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5089,6 +5101,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
       "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -5383,6 +5396,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -5634,6 +5648,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -6315,22 +6330,6 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
-    "node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.180",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.180.tgz",
@@ -6478,6 +6477,7 @@
       "integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6539,6 +6539,7 @@
       "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7044,39 +7045,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-      }
-    },
-    "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/filename-reserved-regex": {
@@ -7739,6 +7707,38 @@
         "node": ">=18"
       }
     },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -8106,7 +8106,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8240,38 +8240,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/jake": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
-      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
-        "filelist": "^1.0.4",
-        "minimatch": "^3.1.2"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jake/node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -9543,6 +9518,7 @@
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.16.2.tgz",
       "integrity": "sha512-52T4XPhDgJL4cqooBsOORzYBH3ddMwABMEF/LV7TgvD2DEKZlnYTc2HF9ch1U2lcKjhE4pQ+WuInfLFJbguGcQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bson": "^6.10.4",
         "kareem": "2.6.3",
@@ -10279,6 +10255,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10522,7 +10499,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",
@@ -10718,6 +10696,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -10792,9 +10771,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -11536,6 +11515,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11792,19 +11772,19 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.0",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.0.tgz",
-      "integrity": "sha512-d423TJMnJGu80/eSgfQ5w/R+0zFJvdtTxwtF9KzFFunOpSeD+79lHJQIiAhluJoyGRbvj9NZJsl9WjCUo0ND7Q==",
+      "version": "29.4.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.5.tgz",
+      "integrity": "sha512-HO3GyiWn2qvTQA4kTgjDcXiMwYQt68a1Y8+JuLRVpdIzm+UOLSHgl/XqR4c6nzJkq5rOkjc02O2I7P7l/Yof0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
-        "ejs": "^3.1.10",
         "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.8",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.2",
+        "semver": "^7.7.3",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -11884,6 +11864,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12030,6 +12011,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12059,6 +12041,20 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/uid": {
@@ -12377,7 +12373,6 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -12396,7 +12391,6 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -12410,7 +12404,6 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -12425,7 +12418,6 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -12435,8 +12427,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/webpack/node_modules/mime-db": {
       "version": "1.52.0",
@@ -12444,7 +12435,6 @@
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -12455,7 +12445,6 @@
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -12469,7 +12458,6 @@
       "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -12522,6 +12510,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "prettier": "^3.4.2",
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",
-    "ts-jest": "^29.2.5",
+    "ts-jest": "^29.4.5",
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -14,8 +14,8 @@ export class VideoDetails {
   @Prop({ type: [String], required: true })
   tags: string[];
 
-  @Prop({ type: String, default: null }) // GridFS ID for thumbnail
-  thumbnailId: string;
+  @Prop({ type: String, default: null })
+  thumbnailUrl: string;
 }
 
 @Schema({ timestamps: true })
@@ -29,20 +29,20 @@ export class Job {
   @Prop({ required: false })
   script: string;
 
-  @Prop({ type: String, default: null }) // GridFS ID for audio
-  audioId: string;
+  @Prop({ type: String, default: null })
+  audioUrl: string;
 
-  @Prop({ type: String, default: null }) // GridFS ID for subtitles
-  subtitleId: string;
+  @Prop({ type: String, default: null })
+  subtitleUrl: string;
 
-  @Prop({ type: [String], default: [] }) // GridFS IDs for video clips
-  videoClipIds: string[];
+  @Prop({ type: [String], default: [] })
+  videoClipUrls: string[];
 
-  @Prop({ type: String, default: null }) // GridFS ID for background music
-  backgroundMusicId: string;
+  @Prop({ type: String, default: null })
+  backgroundMusicUrl: string;
 
-  @Prop({ type: String, default: null }) // GridFS ID for final video
-  finalVideoId: string;
+  @Prop({ type: String, default: null })
+  finalVideoUrl: string;
 
   @Prop({ type: String, default: null }) // YouTube video ID
   youtubeVideoId: string;

--- a/src/video/video.controller.ts
+++ b/src/video/video.controller.ts
@@ -6,21 +6,13 @@ import {
   InternalServerErrorException,
 } from "@nestjs/common";
 import { HttpService } from "@nestjs/axios";
-import { Connection, Model, Types } from "mongoose";
-import { Db, GridFSBucket } from "mongodb";
-import { Readable } from "stream";
+import { Model } from "mongoose";
 import { lastValueFrom } from "rxjs";
-import { InjectConnection, InjectModel } from "@nestjs/mongoose";
-import { FfmpegService } from "src/shared/ffmpeg/ffmpeg.service";
-import { PixabayService } from "src/shared/pixabay/pixabay.service";
-import { MusicService } from "src/shared/music/music.service";
+import { InjectModel } from "@nestjs/mongoose";
 import { ScriptService } from "src/shared/script/script.service";
-import { ThumbNailService } from "src/shared/thumbnail/thumbnail.service";
-import { TTSService } from "src/shared/tts/tts.service";
 import { YoutubeService } from "./video.service";
 import { Job } from "src/schemas";
 import { UtilityService } from "src/shared/utility/utility.service";
-import { StorageService } from "src/shared/storage/storage.service";
 import { ConfigService } from "@nestjs/config";
 
 @Controller("automate/video")
@@ -31,31 +23,22 @@ export class VideoController {
   constructor(
     @InjectModel(Job.name) private readonly jobModel: Model<Job>,
     private readonly scriptService: ScriptService,
-    private readonly pixabayService: PixabayService,
-    private readonly musicService: MusicService,
-    private readonly thumbnailService: ThumbNailService,
-    private readonly ttsService: TTSService,
-    private readonly ffmpegService: FfmpegService,
+    // private readonly pixabayService: PixabayService,
+    // private readonly musicService: MusicService,
+    // private readonly thumbnailService: ThumbNailService,
+    // private readonly ttsService: TTSService,
+    // private readonly ffmpegService: FfmpegService,
     private readonly youtubeService: YoutubeService,
     private readonly httpService: HttpService,
     private readonly utilityService: UtilityService,
-    private readonly storageService: StorageService,
-    @InjectConnection() private readonly connection: Connection,
+    // private readonly storageService: StorageService,
+    // @InjectConnection() private readonly connection: Connection,
     private readonly configService: ConfigService,
   ) {
     this.subtitleUrl = this.configService.get<string>(
       "SUBTITLE_MICROSERVICE_URL",
       "https://yta-subtitle-microservice.onrender.com/subtitles",
     );
-  }
-
-  private async streamToBuffer(stream: Readable): Promise<Buffer> {
-    return new Promise((resolve, reject) => {
-      const chunks: Buffer[] = [];
-      stream.on("data", (chunk) => chunks.push(chunk));
-      stream.on("error", reject);
-      stream.on("end", () => resolve(Buffer.concat(chunks)));
-    });
   }
 
   @Post()
@@ -65,11 +48,9 @@ export class VideoController {
     }
 
     this.logger.log(`Starting video generation for prompt: ${prompt}`);
-    const bucket = new GridFSBucket(this.connection.db as Db);
     const job = new this.jobModel({
-      _id: new Types.ObjectId().toString(),
       prompt,
-      videoDetails: { title: "", description: "", tags: [], thumbnailId: "" },
+      videoDetails: { title: "", description: "", tags: [] },
     });
 
     if (!job || !job._id) {
@@ -77,143 +58,38 @@ export class VideoController {
     }
 
     try {
-      const {
-        script,
-        title,
-        description,
-        tags,
-        imageSearchQuery,
-        videoSearchQuery,
-      } = await this.scriptService.generateScriptAndMetadata(prompt, job);
+      const { script, title, description, tags } =
+        await this.scriptService.generateScriptAndMetadata(prompt, job);
       job.script = script;
       job.videoDetails.title = title;
       job.videoDetails.description = description;
       job.videoDetails.tags = tags;
 
-      // Step 2: Generate media (audio, videos, thumbnail, music)
-      console.time("media-generation-and-raw-storage");
-      const [rawAudioId, musicData, videoClipIds, thumbnailId] =
-        await Promise.all([
-          this.utilityService.retryOperation(async () => {
-            const rawAudioStream = await this.ttsService.synthesizeStream(
-              script,
-              `raw_audio_${job._id.toString()}.raw`,
-            );
-            return this.storageService.storeStream(
-              bucket,
-              rawAudioStream,
-              `raw_audio_${job._id.toString()}.raw`,
-            );
-          }, "Raw Audio generation and storage"),
-          this.utilityService.retryOperation(
-            () => this.musicService.searchSounds(),
-            "Music search",
-          ),
-          this.utilityService.retryOperation(
-            () =>
-              this.pixabayService.searchAndStoreVideoClips(
-                job,
-                bucket,
-                videoSearchQuery,
-              ),
-            "Video search and storage",
-          ),
-          this.utilityService.retryOperation(async () => {
-            const thumbnailStream =
-              await this.thumbnailService.generateThumbnailWithFallback(
-                script,
-                imageSearchQuery,
-                job._id.toString(),
-              );
-            return this.storageService.storeStream(
-              bucket,
-              thumbnailStream,
-              `thumbnail_${job._id.toString()}.png`,
-            );
-          }, "Thumbnail generation and storage"),
-        ]);
-      job.videoClipIds = videoClipIds;
-      job.videoDetails.thumbnailId = thumbnailId;
-      console.timeEnd("media-generation-and-raw-storage");
-
-      await this.ttsService.processAndStoreAudio(job, bucket, rawAudioId);
-
-      await this.musicService.selectAndStoreBackgroundMusic(job, musicData);
-      console.timeEnd("store-media");
-
-      // Step 3: Generate subtitles via FastAPI VOSK
-      console.time("subtitle-generation");
-      const audioDownloadStream = bucket.openDownloadStream(
-        new Types.ObjectId(job.audioId),
+      // Step 2: Generate video using Render endpoint
+      const response = await lastValueFrom(
+        this.httpService.post(
+          "https://mpt-mkrv.onrender.com/api/v1/videos",
+          {
+            video_subject: prompt,
+            video_script: script,
+          },
+        ),
       );
-      const audioBuffer = await this.streamToBuffer(audioDownloadStream);
-      const subtitleResponse = await this.utilityService.retryOperation(
-        async () => {
-          const response = await lastValueFrom(
-            this.httpService.post(this.subtitleUrl, {
-              audio: audioBuffer.toString("base64"),
-            }),
-          );
-          return response.data.srt;
-        },
-        "Subtitle generation",
-      );
-      const subtitleStream = Readable.from(subtitleResponse);
-      const subtitleId = await this.storageService.storeStream(
-        bucket,
-        subtitleStream,
-        `subtitles_${job._id.toString()}.srt`,
-      );
-      job.subtitleId = subtitleId;
-      console.timeEnd("subtitle-generation");
+      const videoUrl = response.data.data.videos[0];
+      job.finalVideoUrl = videoUrl;
 
-      // Step 4: Merge video
-      console.time("video-merge");
-      const finalVideoStream = await this.utilityService.retryOperation(
-        () =>
-          this.ffmpegService.mergeAll({
-            clipStreams: job.videoClipIds.map((id) =>
-              bucket.openDownloadStream(new Types.ObjectId(id)),
-            ),
-            audioStream: bucket.openDownloadStream(
-              new Types.ObjectId(job.audioId),
-            ),
-            musicStream: job.backgroundMusicId
-              ? bucket.openDownloadStream(
-                  new Types.ObjectId(job.backgroundMusicId),
-                )
-              : null,
-            subtitleId: job.subtitleId,
-            thumbnailId: job.videoDetails.thumbnailId,
-            bucket,
-          }),
-        "Video merge",
-      );
-      const finalVideoId = await this.storageService.storeStream(
-        bucket,
-        finalVideoStream,
-        finalVideoStream["filename"],
-      );
-      job.finalVideoId = finalVideoId;
-      console.timeEnd("video-merge");
-
-      // Step 5: Upload to YouTube
-      console.time("video-upload");
-      const uploadResult = await this.utilityService.retryOperation(
-        () =>
-          this.youtubeService.uploadVideoStream(
-            finalVideoStream,
-            job.videoDetails.title,
-            job.videoDetails.description,
-            job.videoDetails.tags,
-            bucket,
-            finalVideoId,
-          ),
-        "Video upload",
+      // Step 3: Upload to YouTube
+      const videoStream = await this.httpService.get(videoUrl, {
+        responseType: "stream",
+      });
+      const uploadResult = await this.youtubeService.uploadVideoStream(
+        videoStream.data,
+        job.videoDetails.title,
+        job.videoDetails.description,
+        job.videoDetails.tags,
       );
       job.youtubeVideoId = uploadResult?.id;
       job.youtubeVideoUrl = uploadResult?.url;
-      console.timeEnd("video-upload");
 
       // Save job to MongoDB
       await job.save();

--- a/src/video/video.service.ts
+++ b/src/video/video.service.ts
@@ -2,7 +2,6 @@ import { Injectable, Logger } from '@nestjs/common';
 import { google } from 'googleapis';
 import { ConfigService } from '@nestjs/config';
 import { Readable } from 'stream';
-import { GridFSBucket } from 'mongodb';
 import mongoose from 'mongoose';
 
 @Injectable()
@@ -47,26 +46,19 @@ export class YoutubeService {
     videoStream: Readable,
     title: string,
     description: string,
-    tags: string[],
-    bucket?: GridFSBucket,
-    finalVideoId?: string
+    tags: string[]
   ): Promise<{ id: string; url: string } | null> {
     if (!this.REFRESH_TOKEN) {
-      this.logger.error('YouTube refresh token not set. Cannot upload video.');
+      this.logger.error("YouTube refresh token not set. Cannot upload video.");
       this.logger.log(
-        'Ensure YOUTUBE_CLIENT_ID, YOUTUBE_CLIENT_SECRET, YOUTUBE_REDIRECT_URI, and YOUTUBE_REFRESH_TOKEN are set in .env.'
+        "Ensure YOUTUBE_CLIENT_ID, YOUTUBE_CLIENT_SECRET, YOUTUBE_REDIRECT_URI, and YOUTUBE_REFRESH_TOKEN are set in .env.",
       );
-      this.logger.log('Perform OAuth flow to obtain a refresh token.');
-      throw new Error('YouTube refresh token missing');
+      this.logger.log("Perform OAuth flow to obtain a refresh token.");
+      throw new Error("YouTube refresh token missing");
     }
 
     try {
-      // If finalVideoId is provided, fetch stream from GridFS
-      let uploadStream = videoStream;
-      if (finalVideoId && bucket) {
-        this.logger.log(`Fetching video stream from GridFS: ${finalVideoId}`);
-        uploadStream = bucket.openDownloadStream(new mongoose.Types.ObjectId(finalVideoId));
-      }
+      const uploadStream = videoStream;
 
       // Validate inputs
       if (!uploadStream) {


### PR DESCRIPTION
This commit refactors the video generation service to use an external Render endpoint, simplifying the architecture and removing the need for local video processing.

Key changes include:
- Replaced local video generation logic with a call to the Render endpoint.
- Removed GridFS implementation in favor of standard MongoDB.
- Updated the database schema to store URLs instead of GridFS IDs.
- Commented out unused services to align with the new architecture.
- Created a comprehensive README with updated setup and usage instructions.