### PR TITLE
fix: Resolve memory leak and complete video generation refactor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      - fastapi
       - mongo
     environment:
       - MONGO_URI=mongodb://mongo:27017/yta-nest-be
@@ -16,10 +15,6 @@ services:
       - YOUTUBE_REDIRECT_URI=${YOUTUBE_REDIRECT_URI}
       - YOUTUBE_REFRESH_TOKEN=${YOUTUBE_REFRESH_TOKEN}
       - API_KEY=${PIXABAY_API_KEY}
-  fastapi:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/yta-vosk-fastapi:latest
-    ports:
-      - "8000:8000"
   mongo:
     image: mongo:latest
     ports:

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@nestjs/mongoose": "^11.0.3",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/schedule": "^6.0.0",
-        "axios": "^1.10.0",
+        "axios": "^1.12.2",
         "cloudinary": "^2.7.0",
         "fluent-ffmpeg": "^2.1.3",
         "googleapis": "^150.0.1",
@@ -5097,14 +5097,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -7252,9 +7252,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@nestjs/mongoose": "^11.0.3",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/schedule": "^6.0.0",
-    "axios": "^1.10.0",
+    "axios": "^1.12.2",
     "cloudinary": "^2.7.0",
     "fluent-ffmpeg": "^2.1.3",
     "googleapis": "^150.0.1",


### PR DESCRIPTION
This commit resolves a critical "JavaScript heap out of memory" error by implementing a true streaming solution for video uploads. It also completes the full refactoring of the video generation service to use an external Render endpoint, simplifying the architecture and improving performance.

Key changes include:
- Replaced NestJS `HttpService` with a direct `axios` call to get a true, unbuffered stream of the video file, preventing it from being loaded into memory.
- Removed the temporary file download logic, as it's no longer needed.
- Optimized the `docker-compose.yml` by removing the unused `fastapi` service to free up system resources.
- Updated the database schema to store URLs instead of GridFS IDs.
- Commented out unused services and methods to align with the new architecture.
- Created a comprehensive README with updated setup and usage instructions.